### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Emaildouble/Settings.php
+++ b/CRM/Emaildouble/Settings.php
@@ -28,7 +28,7 @@ class CRM_Emaildouble_Settings {
 
     $createParams = array();
 
-    if ($optionValueId = CRM_Utils_Array::value('id', $result)) {
+    if ($optionValueId = $result['id'] ?? NULL) {
       $createParams['id'] = $optionValueId;
     }
     else {


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.