### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Emaildouble/Settings.php
+++ b/CRM/Emaildouble/Settings.php
@@ -47,7 +47,7 @@ class CRM_Emaildouble_Settings {
       civicrm_api3('optionValue', 'create', $createParams);
       return TRUE;
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       return FALSE;
     }
   }

--- a/CRM/Emaildouble/Upgrader.php
+++ b/CRM/Emaildouble/Upgrader.php
@@ -55,7 +55,7 @@ class CRM_Emaildouble_Upgrader extends CRM_Extension_Upgrader_Base {
         'id' => $optionGroupId,
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
     }
   }
 


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.